### PR TITLE
set length to 0 to get non-bindable column for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ credits go to the author(s) of this package_
 
 ## The reason for the fork
 
-We have troubles with the Spark `string` type and the `alexbrainman/odbc` package. We have created
+We have troubles with the Spark / Hive `string` type and the `alexbrainman/odbc` package. We have created
 an [issue](https://github.com/alexbrainman/odbc/issues/165) in the original repository explaining
 our issues in detail.
 
-In this fork, we modify some of the column binding operations to work more nicely with Spark.
+In this fork, we modify some of the column binding operations to work more nicely with Spark / Hive.
 
 We also implement the [`driver.QueryerContext`](https://pkg.go.dev/database/sql/driver#QueryerContext)
 which honours the context passed in, and returns when the context times out or gets cancelled.

--- a/column.go
+++ b/column.go
@@ -99,8 +99,11 @@ func NewColumn(h api.SQLHSTMT, idx int) (Column, error) {
 	case api.SQL_VARCHAR:
 		// hack: set length to 0 to get non-bindable column for strings
 		return NewVariableWidthColumn(b, api.SQL_C_CHAR, 0)
-	case api.SQL_WCHAR, api.SQL_WVARCHAR:
+	case api.SQL_WCHAR:
 		return NewVariableWidthColumn(b, api.SQL_C_WCHAR, size)
+	case api.SQL_WVARCHAR:
+		// hack: set length to 0 to get non-bindable column for strings
+		return NewVariableWidthColumn(b, api.SQL_C_WCHAR, 0)
 	case api.SQL_BINARY, api.SQL_VARBINARY:
 		return NewVariableWidthColumn(b, api.SQL_C_BINARY, size)
 	case api.SQL_LONGVARCHAR:


### PR DESCRIPTION
Similarly, We have troubles with the Hive `string` type